### PR TITLE
Updated links to T2M evaluators

### DIFF
--- a/prepare/download_t2m_evaluators.sh
+++ b/prepare/download_t2m_evaluators.sh
@@ -1,6 +1,6 @@
 echo -e "Downloading T2M evaluators"
-gdown --fuzzy https://drive.google.com/file/d/1DSaKqWX2HlwBtVH5l7DdW96jeYUIXsOP/view
-gdown --fuzzy https://drive.google.com/file/d/1tX79xk0fflp07EZ660Xz1RAFE33iEyJR/view
+gdown --fuzzy https://drive.google.com/file/d/1O_GUHgjDbl2tgbyfSwZOUYXDACnk25Kb/view
+gdown --fuzzy https://drive.google.com/file/d/12liZW5iyvoybXD8eOw4VanTgsMtynCuU/view
 rm -rf t2m
 rm -rf kit
 


### PR DESCRIPTION
This pull request addresses the broken links to the T2M Evaluators, as reported in #12. 
The outdated links have been replaced with the correct ones provided by @Mu-Bilal, resolving the issue.