### PR TITLE
Add conda-forge channel to resolve gdown package.

### DIFF
--- a/environment_gmd.yml
+++ b/environment_gmd.yml
@@ -4,6 +4,7 @@ channels:
   - nvidia
   - anaconda
   - defaults
+  - conda-forge
 dependencies:
   - pip
   - ca-certificates


### PR DESCRIPTION
I tried to setup your repository with conda as described in your README. Unfortunately, conda couldn't find the gdown package. On [conda's website](https://anaconda.org/conda-forge/gdown) I found that this package is part of the conda-forge channel. Therefore, I added this channel to the `environment-gmd.yml` file.